### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/{{cookiecutter.deployment_name}}/Top/CMakeLists.txt
+++ b/{{cookiecutter.deployment_name}}/Top/CMakeLists.txt
@@ -15,7 +15,7 @@ set(MOD_DEPS
   Fw/Logger
   Arduino/ArduinoTime
   Arduino/Drv/StreamDriver
-  Os/Baremetal/TaskRunner
+  fprime-baremetal/Os/TaskRunner
 )
 
 register_fprime_module()


### PR DESCRIPTION
Hey team,

Ref: fprime-community/fprime-arduino#31

This PR corrects the following error:
```
CMake Error at fprime/cmake/target/build.cmake:82 (add_dependencies):
-- Generating done (0.7s)
  The dependency target "Os_Baremetal_TaskRunner" of target
  "BroncoDeployment_Top" does not exist.
Call Stack (most recent call first):
  fprime/cmake/target/build.cmake:151 (build_setup_build_module)
  fprime/cmake/target/target.cmake:116 (build_add_module_target)
  fprime/cmake/target/target.cmake:116 (cmake_language)
  fprime/cmake/target/target.cmake:155 (setup_single_target)
  fprime/cmake/module.cmake:42 (setup_module_targets)
  fprime/cmake/module.cmake:82 (generate_base_module_properties)
  fprime/cmake/API.cmake:239 (generate_library)
  BroncoDeployment/Top/CMakeLists.txt:21 (register_fprime_module)
```

@ethancheez I noticed that you haven't changed this in your branch but you mentioned that you were able to build successfully. I notice you're using the expected namespace in your `Main.cpp`. Are you somehow configuring the `fprime-baremetal` namespace to not be an issue for the CMakeLists.txt definition?

### Env
Confirming `settings.ini` changes are in place:
```
cat settings.ini|grep lib
library_locations: ./fprime-arduino:./fprime-baremetal
```
Confirming library vers:
```
Operating System: Darwin
CPU Architecture: arm64
Platform: macOS-15.0.1-arm64-arm-64bit
Python version: 3.9.6
CMake version: 3.30.5
Pip version: 21.2.4
Pip packages:
    fprime-tools==3.5.0
    fprime-gds==3.5.0
    fprime-fpp-*==2.2.0
```
```
cd fprime-arduino/ && git status && cd -
On branch fprime-v3.5.0
Your branch is up to date with 'origin/fprime-v3.5.0'.

nothing to commit, working tree clean
```
```
cd fprime-baremetal/ && git status && cd -
On branch update/v3.5.0-ethan
Your branch is up to date with 'origin/update/v3.5.0-ethan'.

nothing to commit, working tree clean
```